### PR TITLE
hotfix for parsing error when whitespace before closing tag

### DIFF
--- a/interfaces/xml.js
+++ b/interfaces/xml.js
@@ -1114,7 +1114,7 @@ mivIxml2jxon.prototype = {
 										}
 									}
 
-									if ((tmpStart < strLength) && ((aString.substr(tmpStart,1) == "/") || (aString.substr(tmpStart,1) == ">"))) {
+									if ((tmpStart < strLength) && ((aString.substr(tmpStart,1) == "/") || (aString.substr(tmpStart,1) == ">")) && (attribute.length > 0)) {
 										this.logInfo("b. Found attribute '"+attribute+"' for tag '"+this.tagName+"'",2);
 										attributes.push(attribute);
 										this.explodeAttribute(attribute);


### PR DESCRIPTION
Fixes part of Bugzilla bug 132.
