### PR TITLE
GUI option to enable/disable Kerberos authentication

### DIFF
--- a/chrome/content/exchangeSettingsOverlay.js
+++ b/chrome/content/exchangeSettingsOverlay.js
@@ -63,6 +63,7 @@ var exchWebServicesgMailbox = "";
 var exchWebServicesgDisplayName = "";
 var exchWebServicesgUser = "";
 var exchWebServicesgDomain = "";
+var exchWebServicesgUseKerberos = false;
 var exchWebServicesgFolderIdOfShare = "";
 var exchWebServicesgFolderBase = "calendar";
 var exchWebServicesgFolderPath = "/";
@@ -211,6 +212,13 @@ function exchWebServicesAutodiscoverCheckbox(aCheckBox)
 	exchWebServicesCheckRequired();
 }
 
+function exchWebServicesUseKerberosCheckbox(aCheckBox)
+{
+	exchWebServicesgUseKerberos = aCheckBox.checked;
+	gexchWebServicesDetailsChecked = false;
+	exchWebServicesCheckRequired();
+}
+
 function exchWebServicesInitMailbox(aNewValue)
 {
 	exchWebServicesgMailbox = aNewValue;
@@ -328,6 +336,7 @@ function exchWebServicesDoCheckServerAndMailbox()
 			var tmpObject = new erConvertIDRequest(
 				{user: exchWebServicesGetUsername(), 
 				 mailbox: exchWebServicesgMailbox,
+				 kerberos: exchWebServicesgUseKerberos,
 				 serverUrl: exchWebServicesgServer,
 				 folderId: folderIdOfShare}, exchWebServicesConvertIDOK, exchWebServicesConvertIDError);
 		}
@@ -335,6 +344,7 @@ function exchWebServicesDoCheckServerAndMailbox()
 			var tmpObject = new erPrimarySMTPCheckRequest(
 				{user: exchWebServicesGetUsername(), 
 				 mailbox: exchWebServicesgMailbox,
+				 kerberos: exchWebServicesgUseKerberos,
 				 serverUrl: exchWebServicesgServer,
 				 folderBase: "calendar"}, exchWebServicesCheckServerAndMailboxOK, exchWebServicesCheckServerAndMailboxError);
 		}
@@ -354,6 +364,7 @@ function exchWebServicesConvertIDOK(aFolderID, aMailbox)
 		var tmpObject = new erGetFolderRequest(
 			{user: exchWebServicesGetUsername(), 
 			 mailbox: aMailbox,
+			 kerberos: exchWebServicesgUseKerberos,
 			 serverUrl: exchWebServicesgServer,
 			 folderID: aFolderID}, exchWebServicesGetFolderOK, exchWebServicesGetFolderError);
 	}
@@ -529,7 +540,8 @@ function exchWebServicesDoAutodiscoverCheck()
 		window.setCursor("wait");
 	var tmpObject = new erAutoDiscoverRequest( 
 		{user: exchWebServicesGetUsername(), 
-		 mailbox: exchWebServicesgMailbox}, 
+		 mailbox: exchWebServicesgMailbox,
+		 kerberos: exchWebServicesgUseKerberos}, 
 		 exchWebServicesAutodiscoveryOK, 
 		 exchWebServicesAutodiscoveryError, null)
 	}
@@ -644,8 +656,9 @@ function exchWebServicesLoadExchangeSettingsByCalId(aCalId)
 			document.getElementById("menuitem.label.ecfolderbase.publicfoldersroot").disabled = false;
 		}
 
+		document.getElementById("exchWebService_usekerberos").checked = exchWebServicesCalPrefs.getBoolPref("ecUseKerberos");
 
-
+		exchWebServicesgUseKerberos = exchWebServicesCalPrefs.getBoolPref("ecUseKerberos");
 		exchWebServicesgServer = exchWebServicesCalPrefs.getCharPref("ecServer");
 		exchWebServicesgUser = exchWebServicesCalPrefs.getCharPref("ecUser");
 		exchWebServicesgDomain = exchWebServicesCalPrefs.getCharPref("ecDomain");
@@ -679,6 +692,7 @@ function exchWebServicesSaveExchangeSettingsByCalId(aCalId)
 
 	if (exchWebServicesCalPrefs) {
 		exchWebServicesCalPrefs.setCharPref("ecServer", exchWebServicesgServer);
+		exchWebServicesCalPrefs.setBoolPref("ecUseKerberos", exchWebServicesgUseKerberos);
 		exchWebServicesCalPrefs.setCharPref("ecUser", exchWebServicesgUser);
 		exchWebServicesCalPrefs.setCharPref("ecDomain", exchWebServicesgDomain);
 		exchWebServicesCalPrefs.setCharPref("ecFolderpath", exchWebServicesgFolderPath);
@@ -766,6 +780,7 @@ function exchWebServicesLoadExchangeSettingsByContactUUID(aUUID)
 		exchWebServicesgServer = exchWebServicesCalPrefs.getCharPref("server");
 		exchWebServicesgUser = exchWebServicesCalPrefs.getCharPref("user");
 		exchWebServicesgDomain = exchWebServicesCalPrefs.getCharPref("domain");
+		exchWebServicesgUseKerberos = exchWebServicesCalPrefs.getBoolPref("kerberos");
 
 		exchWebServicesgFolderBase = exchWebServicesCalPrefs.getCharPref("folderbase");
 		exchWebServicesgFolderPath = exchWebServicesCalPrefs.getCharPref("folderpath");
@@ -802,6 +817,7 @@ function exchWebServicesSaveExchangeSettingsByContactUUID(isNewDirectory, aUUID)
 		exchWebServicesCalPrefs.setCharPref("server", exchWebServicesgServer);
 		exchWebServicesCalPrefs.setCharPref("user", exchWebServicesgUser);
 		exchWebServicesCalPrefs.setCharPref("domain", exchWebServicesgDomain);
+		exchWebServicesCalPrefs.setBoolPref("kerberos", exchWebServicesgUseKerberos);
 		exchWebServicesCalPrefs.setCharPref("folderpath", exchWebServicesgFolderPath);
 	exchWebService.commonFunctions.LOG("exchWebServicesSaveExchangeSettingsByContactUUID: folderbase:"+exchWebServicesgFolderBase);
 		exchWebServicesCalPrefs.setCharPref("folderbase", exchWebServicesgFolderBase);
@@ -824,6 +840,7 @@ function exchWebServicesSaveExchangeSettingsByContactUUID(isNewDirectory, aUUID)
 			mailbox: exchWebServicesgMailbox,
 			user: exchWebServicesgUser,
 			domain: exchWebServicesgDomain,
+			kerberos: exchWebServicesgUseKerberos,
 			serverUrl: exchWebServicesgServer,
 			folderBase: exchWebServicesgFolderBase,
 			folderPath: exchWebServicesgFolderPath,

--- a/chrome/content/exchangeSettingsOverlay.xul
+++ b/chrome/content/exchangeSettingsOverlay.xul
@@ -48,6 +48,7 @@
 
 	<vbox id="exchWebService-exchange-settings">
 		<checkbox label="&ecautodiscover;" id="exchWebService_autodiscover" oncommand="exchWebServicesAutodiscoverCheckbox(this);"/>
+		<checkbox label="&ecusekerberos;" id="exchWebService_usekerberos" oncommand="exchWebServicesUseKerberosCheckbox(this);"/>
         	<grid flex="1">
         	    <columns>
         	        <column/>

--- a/chrome/content/manageEWSAccounts.js
+++ b/chrome/content/manageEWSAccounts.js
@@ -120,6 +120,9 @@ exchWebService.manageEWSAccounts = {
 	{
 		document.getElementById("exchWebService_autodiscover").disabled = false;
 
+		document.getElementById("exchWebService_usekerberos").checked = aAccount.kerberos;
+		document.getElementById("exchWebService_usekerberos").disabled = false;
+
 		document.getElementById("exchWebService_manageEWSAccounts_account_name").value = aAccount.name;
 		document.getElementById("exchWebService_manageEWSAccounts_account_name").disabled = false;
 
@@ -136,6 +139,9 @@ exchWebService.manageEWSAccounts = {
 	disableDetails: function _showDetails(aAccount)
 	{
 		document.getElementById("exchWebService_autodiscover").disabled = true;
+
+		document.getElementById("exchWebService_usekerberos").checked = false;
+		document.getElementById("exchWebService_usekerberos").disabled = true;
 
 		document.getElementById("exchWebService_manageEWSAccounts_account_name").value = "";
 		document.getElementById("exchWebService_manageEWSAccounts_account_name").disabled = true;
@@ -186,7 +192,8 @@ exchWebService.manageEWSAccounts = {
 				name: "new Account",
 				server: "",
 				user: "",
-				mailbox: "" };
+				mailbox: "",
+				kerberos: false };
 		exchWebService.accountFunctions.saveAccount(this.selectedAccount);
 		var listbox = document.getElementById("exchWebService-manageEWSAccounts-accounts-listbox");
 		if (listbox) {
@@ -278,6 +285,13 @@ exchWebService.manageEWSAccounts = {
 		this.selectedAccount.user = aTextBox.value;
 	},
 
+	doUseKerberosChanged: function _doUseKerberosChanged(aCheckBox)
+	{
+		this.detailsChecked = false;
+		this.detailsChanged = true;
+		this.selectedAccount.kerberos = aCheckBox.checked;
+	},
+
 	doAutodiscoverCheck: function _doAutodiscoverCheck()
 	{
 		document.getElementById("exchWebService_autodiscovercheckbutton").disabled = true;
@@ -286,9 +300,11 @@ exchWebService.manageEWSAccounts = {
 			window.setCursor("wait");
 			var user = document.getElementById("exchWebService_windowsuser").value;
 			var mailbox = document.getElementById("exchWebService_mailbox").value;
+			var kerberos = document.getElementById("exchWebService_usekerberos").checked;
 			var tmpObject = new erAutoDiscoverRequest( 
 				{user: user, 
-				 mailbox: mailbox}, 
+				 mailbox: mailbox,
+				 kerberos: kerberos}, 
 				 this.autodiscoveryOK, 
 				 this.autodiscoveryError, null);
 		}

--- a/chrome/content/manageEWSAccounts.xul
+++ b/chrome/content/manageEWSAccounts.xul
@@ -52,6 +52,7 @@
 					 oninput="exchWebService.manageEWSAccounts.doNameChanged(this)"/>
 			</hbox>
 			<checkbox disabled="true" label="&exchWebService.manageEWSAccounts.autodiscover.label;" id="exchWebService_autodiscover" oncommand="exchWebService.manageEWSAccounts.doAutodiscoverChanged(this);"/>
+			<checkbox disabled="true" label="&exchWebService.manageEWSAccounts.usekerberos.label;" id="exchWebService_usekerberos" oncommand="exchWebService.manageEWSAccounts.doUsekerberosChanged(this);"/>
 			<grid flex="1">
 			    <columns>
 			        <column/>

--- a/components/accountFunctions.js
+++ b/components/accountFunctions.js
@@ -118,6 +118,9 @@ exchWebService.accountFunctions = {
 				case "number":
 					this.prefs.setIntPref(aAccount.id+"."+index, aAccount[index]);
 					break;
+				case "boolean":
+					this.prefs.setBoolPref(aAccount.id+"."+index, aAccount[index]);
+					break;
 				default:
 					this.logInfo("Unknown object index:"+index);
 				}

--- a/interfaces/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
+++ b/interfaces/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
@@ -164,22 +164,17 @@ mivExchangeAuthPrompt2.prototype = {
 
 try {
 		if (!password) {
-
-			if (!this.details[aURL]) { 
-				this.logInfo("getPassword: First request for a password. Not going to ask user for it because we want to see if we need a password. For Kerberos for example we do not need a password.");
-				return null;
-			}
-
-/*			if (!this.details[aURL]) this.details[aURL] = { 
+			if (!this.details[aURL]) this.details[aURL] = { 
 							showing: true, 
 							canceled: false,
 							queue: new Array(),
 							ntlmCount: 0
-						};*/
+						}; 
 
 			this.logInfo("getPassword: Going to ask user to provide a new password.");
-
+	
 			this.details[aURL].ntlmCount = 0;
+	
 			var answer = this.getCredentials(username, aURL);
 
 			if (answer.result) {

--- a/locale/exchangecalendar/de/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/de/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Exchange's Autodiscovery Funktion nutzen.">
+<!ENTITY ecusekerberos "Use Kerberos authentication.">
 <!ENTITY ecfolderbase.label "Hauptordner:">
 <!ENTITY ecfolderpath.label "Pfad unterhalb des Hauptordners:">
 <!ENTITY ecfolderidofshare.label "Freigabeordner Id:">

--- a/locale/exchangecalendar/de/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/de/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Einstellungen speichern">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Exchange's Autodiscovery Funktion nutzen.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Use Kerberos authentication.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Postfachname:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Benutzername:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domainname:">

--- a/locale/exchangecalendar/en-US/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/en-US/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Use Exchange's autodiscovery function.">
+<!ENTITY ecusekerberos "Use Kerberos authentication.">
 <!ENTITY ecfolderbase.label "Folder base:">
 <!ENTITY ecfolderpath.label "Path below folder base:">
 <!ENTITY ecfolderidofshare.label "Share Folder Id:">

--- a/locale/exchangecalendar/en-US/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/en-US/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Save settings">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Use Exchange's autodiscovery function.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Use Kerberos authentication.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailbox name:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Username:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domain name:">

--- a/locale/exchangecalendar/fr-FR/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/fr-FR/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Utiliser la fonction de découverte automatique d'Exchange.">
+<!ENTITY ecusekerberos "Utiliser authentification Kerberos.">
 <!ENTITY ecfolderbase.label "Dossier racine:">
 <!ENTITY ecfolderpath.label "Chemin sous le dossier racine:">
 <!ENTITY ecfolderidofshare.label "Dossier partagé:">

--- a/locale/exchangecalendar/fr-FR/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/fr-FR/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Sauvegarder le compte">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Utiliser la fonction de découverte automatique d'Exchange.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Utiliser authentification Kerberos.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Nom de la boite aux lettres:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Utilisateur:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Nom de Domaine:">

--- a/locale/exchangecalendar/ja-JP/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/ja-JP/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Use Exchange's autodiscovery function.">
+<!ENTITY ecusekerberos "Use Kerberos authentication.">
 <!ENTITY ecfolderbase.label "Folder base:">
 <!ENTITY ecfolderpath.label "Path below folder base:">
 <!ENTITY ecfolderidofshare.label "Share Folder Id:">

--- a/locale/exchangecalendar/ja-JP/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/ja-JP/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Save settings">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Use Exchange's autodiscovery function.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Use Kerberos authentication.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailbox name:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Username:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domain name:">

--- a/locale/exchangecalendar/nl/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/nl/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Gebruik autodiscovery functie van Exchange.">
+<!ENTITY ecusekerberos "Use Kerberos authentication.">
 <!ENTITY ecfolderbase.label "Basisfolder:">
 <!ENTITY ecfolderpath.label "Pad onder basis:">
 <!ENTITY ecfolderidofshare.label "Share FolderId:">

--- a/locale/exchangecalendar/nl/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/nl/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Bewaar gegevens">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Gebruik autodiscovery functie van Exchange.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Use Kerberos authentication.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailboxnaam:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Gerbuikersnaam:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domeinnaam:">

--- a/locale/exchangecalendar/sv/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/sv/exchangeSettingsOverlay.dtd
@@ -1,4 +1,5 @@
 <!ENTITY ecautodiscover "Använd Exchanges funktion för automatisk utforskning.">
+<!ENTITY ecusekerberos "Use Kerberos authentication.">
 <!ENTITY ecfolderbase.label "Basmapp:">
 <!ENTITY ecfolderpath.label "Sökväg under basmapp:">
 <!ENTITY ecfolderidofshare.label "Basmapps-ID:">

--- a/locale/exchangecalendar/sv/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/sv/manageEWSAccounts.dtd
@@ -5,6 +5,7 @@
 <!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Spara inställningar">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Använd Exchanges funktion för automatisk utforskning.">
+<!ENTITY exchWebService.manageEWSAccounts.usekerberos.label "Use Kerberos authentication.">
 <!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Namn på postlåda:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Användarnamn:">
 <!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domännamn:">


### PR DESCRIPTION
Current exchangecalendar does not expose Kerberos authentication option in the GUI making debugging problems and setting up little bit confusing for both users and support ...

Proposed request adds an 'Use Kerberos authentication' option to the GUI and changes authentication algorithm to make the extension authenticate:
- using Kerberos only if selected.
- using password only if Kerberos not selected (and not doing fallback to Kerberos)

Best Regards

Jarek
