### PR TITLE
Do not log passwords in clear text (#335).

### DIFF
--- a/history.en_US.txt
+++ b/history.en_US.txt
@@ -108,7 +108,7 @@ Version 3.1.2:
 - Added extra info to progress indicator. It now also uses the new loadbalancer for the statistics.
 
 Version 3.1.1:
-- Fixed bug 205 Extension overwrites URI for non-echange calendars
+- Fixed bug 205 Extension overwrites URI for non-exchange calendars
 
 Version 3.1.0:
 - Fixed part of bug51. When emailaddress of attendee is empty do not throw an error.

--- a/interfaces/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
+++ b/interfaces/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
@@ -135,7 +135,7 @@ mivExchangeAuthPrompt2.prototype = {
 		else {
 			this.logInfo("getPassword: There is no password in the passwordCache["+username+"|"+aURL+"|"+realm+"]");
 		}
-		this.logInfo("getPassword: password(1)="+password);
+		this.logInfo("getPassword: password(1)= *******");
 
 		if (!password) {
 			this.logInfo("getPassword: There is no password in the cache. Going to see if there is one in the passwordManager.");
@@ -148,7 +148,7 @@ mivExchangeAuthPrompt2.prototype = {
 				this.logInfo("getPassword: There is no password stored in the passwordManager.");
 			}
 		}
-		this.logInfo("getPassword: password(2)="+password);
+		this.logInfo("getPassword: password(2)= *******");
 
 		if ((password) && (aChannel) && (aChannel.URI.password) && (decodeURIComponent(aChannel.URI.password) != "")) {
 			this.logInfo("getPassword: There was a password in cache or passwordManager and one on the channel. Going to see if they are the same.");
@@ -169,7 +169,7 @@ mivExchangeAuthPrompt2.prototype = {
 				else {
 					this.logInfo("getPassword: There was a password in cache or passwordManager and one on the channel. And useCached specified.");
 				}
-				this.logInfo("getPassword: cached/store='"+password+"', on channel='"+decodeURIComponent(aChannel.URI.password)+"'.");
+				this.logInfo("getPassword: cached/store='*******', on channel='"+decodeURIComponent(aChannel.URI.password)+"'.");
 			}
 		}
 
@@ -195,7 +195,7 @@ mivExchangeAuthPrompt2.prototype = {
 
 			if (answer.result) {
 				password = answer.password;
-				this.logInfo("getPassword: User specified a password:"+password);
+				this.logInfo("getPassword: User specified a password: *******");
 				if (answer.save) {
 					this.logInfo("getPassword: User requested to store password in passwordmanager.");
 					this.passwordManagerSave(username, password, aURL, realm);
@@ -213,7 +213,7 @@ mivExchangeAuthPrompt2.prototype = {
 			}
 		}
 
-		this.logInfo("getPassword: We have a password:"+password);
+		this.logInfo("getPassword: We have a password: *******");
 
 //} catch(err) { this.logInfo("getPassword: Error:"+err); }
 		return password;

--- a/locale/exchangecalendar/ja-JP/calExchangeCalendar.properties
+++ b/locale/exchangecalendar/ja-JP/calExchangeCalendar.properties
@@ -45,5 +45,5 @@ ecErrorServerAndMailboxCheckFolderNotFound=選択した受信箱について、�
 
 tooltipCalendarDisconnected=The calendar %1$S is not connected to the exchange server\n(Reason: %2$S).
 tooltipCalendarDisconnectedReadOnly=The calendar %1$S is not connected to the exchange server and is readonly\n(Reason: %2$S).
-tooltipCalendarConnected=The calendar %1$S is connected to the echange server.
-tooltipCalendarConnectedReadOnly=The calendar %1$S is connected to the echange server and is readonly.
+tooltipCalendarConnected=The calendar %1$S is connected to the exchange server.
+tooltipCalendarConnectedReadOnly=The calendar %1$S is connected to the exchange server and is readonly.


### PR DESCRIPTION
This is an attempt to fix bug #335, although it is not clear to me how to treat e.g. this command: `decodeURIComponent(aChannel.URI.password)`

Additionally, some missing x characters were added.
